### PR TITLE
assert controller transfers against transfer restrictions in validation contracts

### DIFF
--- a/packages/tezos/contracts/token/FA1.2.py
+++ b/packages/tezos/contracts/token/FA1.2.py
@@ -391,9 +391,7 @@ class FA12_core(Ledger):
                 )
             )
 
-        # verify transfer if not controller
-        sp.if ~self.is_controller(sp.sender):
-            self.assertTransfer(sp.record(from_ = params.from_, to_ = params.to_))
+        self.assertTransfer(sp.record(from_ = params.from_, to_ = params.to_))
 
         self.add_address_if_necessary(params.to_)
 

--- a/packages/tezos/contracts/token/FA2.py
+++ b/packages/tezos/contracts/token/FA2.py
@@ -657,14 +657,12 @@ class FA2_core(Ledger):
         sp.if self.is_paused():
             sp.verify(self.is_controller(sp.sender))
         
-        # verify transfer if not controller
-        sp.if ~self.is_controller(sp.sender):
-            self.assertTransfer(
-                sp.record(
-                    from_=params.from_, 
-                    to_=params.to_
-                )
+        self.assertTransfer(
+            sp.record(
+                from_=params.from_, 
+                to_=params.to_
             )
+        )
         
         if self.config.single_asset:
             sp.verify(params.token_id == 0, "single-asset: token-id <> 0")


### PR DESCRIPTION
Using TZIP-15's entrypoint `assertTransfer` would restrict the `controller` from performing some intervention actions example moving tokens out of a blocked/blacklisted address.

I have made use of a non standard entrypoint `assertTransfer` that passes in the `operator`  address. This would allow the validation contract to `assertRole` of the operator while checking restrictions.

An additional parameter to `assertTransfer` could be `roles` associated to the operator address. This way, the validator contract would not need to call the token contract to `assertRole` for the operator.